### PR TITLE
Add readthedocs.yml for documentation

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,0 +1,3 @@
+python:
+  version: 3
+  pip_install: true


### PR DESCRIPTION
This commit adds a new file `readthedocs.yml` which configures the documentation build for the project on Read the Docs. The configuration includes specifying the Python version, installing dependencies from `requirements.txt`.

The file is added to the root of the project directory.

Fixes #1